### PR TITLE
Ability overwrite cap command - added `command` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ More information:
 
 * `tasks` (optional, default: `deploy`) The tasks which will be run.
 * `stage` (optional) The stage which will be used for the deployment. Requires [multistage extension](https://github.com/capistrano/capistrano/wiki/2.x-Multistage-Extension).
+* `command` (optional, default: `bundle exec cap`) command to run.
 
 # Example
 
@@ -43,6 +44,10 @@ Note however that this will also apply to your local repository, so another reco
 The MIT License (MIT)
 
 # Changelog
+
+## 0.0.5
+
+- Ability overwrite cap command, added `command` option
 
 ## 0.0.4
 

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,10 @@
 
 cap_command="bundle exec cap"
 
+if [ -n "$WERCKER_CAP_COMMAND" ] ; then
+    cap_command=$WERCKER_CAP_COMMAND
+fi
+
 # Parse some variable arguments
 if [ -n "$WERCKER_CAP_STAGE" ] ; then
     cap_command="$cap_command $WERCKER_CAP_STAGE"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: cap
-version: 0.0.4
+version: 0.0.5
 description: cap step
 keywords:
   - capistrano


### PR DESCRIPTION
I noticed that on Ewok stack `bundle exec cap` not works, but `cap`.